### PR TITLE
Add floating table header and move content to <tbody>

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -36,6 +36,8 @@
 	  <th>Warnings <sup><a href="#warnings">#</a></sup></th>
 	  <th>Status</th>
 	</thead>
+	<tbody>
+	</tbody>
       </table>
 
       <div id="spinner" class="spinner"></div>
@@ -57,5 +59,13 @@
 
     <script src="sparkline.js"></script>
     <script src="ssltest.js"></script>
+
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/floatthead/1.2.13/jquery.floatThead.min.js"></script>	
+	<script type="text/javascript">
+	$('#resultsTable').floatThead({
+		useAbsolutePositioning: false
+	});
+	</script>
   </body>
 <html>

--- a/web/ssltest.css
+++ b/web/ssltest.css
@@ -11,6 +11,7 @@ table {
 th {
     font-size: large;
     vertical-align: bottom;
+	background-color: white;
 }
 
 table, th, td {

--- a/web/ssltest.js
+++ b/web/ssltest.js
@@ -26,7 +26,7 @@ function sortByKey(array, key) {
 
 function displayResults(input) {
     var SSLTESTURL = "https://www.ssllabs.com/ssltest/analyze.html";
-    var table = document.getElementById("resultsTable");
+    var table = document.getElementById("resultsTable").getElementsByTagName('tbody')[0];;
     data = input.results;
     var summary = {"A": 0, "B": 0, "C": 0, "D": 0, "E": 0, "F": 0, "X": 0 };
     var totalOrgs = data.length;


### PR DESCRIPTION
Having the table header visible when browsing through a lot of rows is always handy. 
This uses jQuery and a plugin called floatTHead which are hosted on cloudflare.
